### PR TITLE
Reveal Component Utility

### DIFF
--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -273,6 +273,9 @@ That's it! Now, when the page loads, `app/scripts/app.js` kicks off the module r
 
 _Note: The module loader passes a jQuery object of the element that contains `data-module`. This allows for easy scoping if you need to load more than one instance of the module on a page._
 
+#### Using the Component Reveal Functionality
+Init comes with a reveal utility that allows for the highlighting of components on a particular page. To highlight a component simply pass in a search query at the end of the url `?r=[COMPONENT SELECTOR]`. For example to hightlight all the .example-cards components, simply pass in this query in the url, `?r=.example-card`. This query value can be any valid jQuery selector.
+
 ##### Using Third-Party Libraries/Plugins
 Some plugins might not be available via NPM. Rather than use another package manager, we can leverage [Napa](https://www.npmjs.com/package/napa). Add the repo URL to the `napa` object in the `package.json` folder and reference it just like an NPM package.
 

--- a/app/templates/app/scripts/app.js
+++ b/app/templates/app/scripts/app.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var $ = require('jquery');
+var ComponentReveal = require('./modules/componentReveal/componentReveal.main');
+var componentReveal = new ComponentReveal();
 var moduleRegistry = require('./modules/');
 
 moduleRegistry.init();

--- a/app/templates/app/scripts/modules/componentReveal/componentReveal.load.js
+++ b/app/templates/app/scripts/modules/componentReveal/componentReveal.load.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = ($el) => {
+
+  require.ensure([], (require) => {
+
+    var Module = require('./componentReveal.main');
+    new Module($el);
+
+  });
+
+};

--- a/app/templates/app/scripts/modules/componentReveal/componentReveal.main.js
+++ b/app/templates/app/scripts/modules/componentReveal/componentReveal.main.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var $ = require('jquery');
+
+module.exports = class ComponentReveal{
+  constructor($el){
+		(function componentReveal(){
+			var host = window.location.host;
+			var hostCheck = function(urlTarget, hostToCheck){
+				var innerHost = hostToCheck.match(urlTarget);
+				if(innerHost !== null){
+					return true;
+				}
+			};
+			if(hostCheck('localhost', host) || hostCheck('phpstage', host)){
+				var search = window.location.search;
+				if(search !== ''){
+					search = search.split('?r=');
+					var revealTarget = $('' + search[1] + '');
+					if(revealTarget.length > 0){
+						var overlay = $('<div></div>', {
+							'class':'reveal-overlay'
+						}).appendTo('body');
+						$('body').addClass('reveal-adjust');
+						revealTarget.addClass('reveal');
+					}
+				}
+			}
+		})();
+  }
+};

--- a/app/templates/app/scripts/modules/componentReveal/componentReveal.main.js
+++ b/app/templates/app/scripts/modules/componentReveal/componentReveal.main.js
@@ -4,28 +4,26 @@ var $ = require('jquery');
 
 module.exports = class ComponentReveal{
   constructor($el){
-		(function componentReveal(){
-			var host = window.location.host;
-			var hostCheck = function(urlTarget, hostToCheck){
-				var innerHost = hostToCheck.match(urlTarget);
-				if(innerHost !== null){
-					return true;
-				}
-			};
-			if(hostCheck('localhost', host) || hostCheck('phpstage', host)){
-				var search = window.location.search;
-				if(search !== ''){
-					search = search.split('?r=');
-					var revealTarget = $('' + search[1] + '');
-					if(revealTarget.length > 0){
-						var overlay = $('<div></div>', {
-							'class':'reveal-overlay'
-						}).appendTo('body');
-						$('body').addClass('reveal-adjust');
-						revealTarget.addClass('reveal');
-					}
+		var host = window.location.host;
+		var hostCheck = function(urlTarget, hostToCheck){
+			var innerHost = hostToCheck.match(urlTarget);
+			if(innerHost !== null){
+				return true;
+			}
+		};
+		if(hostCheck('localhost', host) || hostCheck('phpstage', host)){
+			var search = window.location.search;
+			if(search !== ''){
+				search = search.split('?r=');
+				var revealTarget = $('' + search[1] + '');
+				if(revealTarget.length > 0){
+					var overlay = $('<div></div>', {
+						'class':'reveal-overlay'
+					}).appendTo('body');
+					$('body').addClass('reveal-adjust');
+					revealTarget.addClass('reveal');
 				}
 			}
-		})();
+		}
   }
 };

--- a/app/templates/app/scripts/modules/index.js
+++ b/app/templates/app/scripts/modules/index.js
@@ -9,6 +9,7 @@ module.exports = {
     });
   },
   modules: {
+    componentReveal: require('./componentReveal/componentReveal.load'),
     sampleModule: require('./sampleModule/sampleModule.load')
   }
 

--- a/app/templates/app/styles/1_core/_helpers.reveal.scss
+++ b/app/templates/app/styles/1_core/_helpers.reveal.scss
@@ -1,0 +1,24 @@
+.reveal-adjust{
+	*{
+		transform:none !important;
+		z-index:auto !important;
+	}
+	.reveal{
+		background-color:#fff !important;
+		outline:1px solid red;
+		position:relative;
+		z-index:3000 !important;
+	}
+	.reveal-overlay{
+		background-color:#000;
+		bottom:0;
+		height:100%;
+		left:0;
+		opacity:0.5;
+		position:fixed;
+		right:0;
+		top:0;
+		width:100%;
+		z-index:2000;
+	}
+}

--- a/app/templates/app/styles/4_regions/_placeholder.scss
+++ b/app/templates/app/styles/4_regions/_placeholder.scss
@@ -1,0 +1,3 @@
+.placeholder{
+
+}

--- a/app/templates/app/styles/5_pages/_placeholder.scss
+++ b/app/templates/app/styles/5_pages/_placeholder.scss
@@ -1,0 +1,3 @@
+.placeholder{
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-gnorm",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Genuine Norm (GNorm) is an all-encompassing starting point for Genuine UI projects that provides architectural direction, fast scaffolding, code familiarity and promotes developer scalability.",
   "files": [
     "app"


### PR DESCRIPTION
## Description
- Added a reveal component utility to Gnorm allowing a direct link to a highlighted component on a page.
- Added a temp fix to the 4_regions and 5_pages sass folders to fix a sass compile bug
## Code Affected
-  app/templates/_README.md
-  app/templates/app/scripts/app.js
-  app/templates/app/scripts/modules/componentReveal/componentReveal.load.js (Added)
-  app/templates/app/scripts/modules/componentReveal/componentReveal.main.js (Added)
-  app/templates/app/scripts/modules/index.js
-  app/templates/app/styles/1_core/_helpers.reveal.scss (Added)
-  app/templates/app/styles/4_regions/_placeholder.scss (Added)
-  app/templates/app/styles/5_pages/_placeholder.scss (Added)
-  package.json
